### PR TITLE
Agrega Cloudflare Web Analytics y elimina atribución Mec&Tronic

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,7 +695,7 @@
                     </ul>
                 </div> <!-- end of col -->
                 <div class="col-lg-6">
-                    <p class="p-small statement">Copyright © <a class="p-small statement" href="https://inovatik.com" target="_blank">Landing Page Template - Inovatik - </a> <a class="p-small statement" href="https://www.mecantronic.com.ar/" target="_blank">Adaptado por Mec&Tronic</a></p>
+                    <p class="p-small statement">Copyright © <a class="p-small statement" href="https://inovatik.com" target="_blank">Landing Page Template - Inovatik</a></p>
                 </div> <!-- end of col -->
             </div> <!-- enf of row -->
         </div> <!-- end of container -->
@@ -714,6 +714,10 @@
     <script src="static/js/mixer_audioMain.js"></script> <!-- Custom mixer main scripts -->  
     <script src="static/js/mixer_components.js"></script> <!-- Custom mixer components scripts --> 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.6.0/gsap.min.js"></script> <!-- Timer animation --> 
+
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "8c3df35538354bb1a731237de19f7abf"}'></script>
+    <!-- End Cloudflare Web Analytics -->
 
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- Inserta el beacon de **Cloudflare Web Analytics** antes de `</body>` para medir tráfico del sitio (visitas, países, referrers, dispositivos).
- Elimina el crédito "Adaptado por Mec&Tronic" del footer (se mantiene la atribución de Inovatik, requerida por la licencia CC del template).

## Notas
- GitHub Pages sirve desde `master`, por lo que el analytics empezará a registrar datos una vez mergeado y republicado (~24-48 hs para ver datos en el panel de Cloudflare).
- El método usado es el snippet manual (JS), ya que el DNS del dominio está en Namecheap, no en Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)